### PR TITLE
#19: consistently use RGB as input to network

### DIFF
--- a/keras_yolov2/frontend.py
+++ b/keras_yolov2/frontend.py
@@ -222,6 +222,8 @@ class YOLO(object):
             image = image[..., np.newaxis]
 
         image = cv2.resize(image, (self._input_size[1], self._input_size[0]))
+        image = image[..., ::-1]  # make it RGB (it is important for normalization of some backends)
+
         image = self._feature_extractor.normalize(image)
         if len(image.shape) == 3:
             input_image = image[np.newaxis, :]

--- a/keras_yolov2/preprocessing.py
+++ b/keras_yolov2/preprocessing.py
@@ -357,7 +357,7 @@ class BatchGenerator(Sequence):
         image = cv2.resize(image, (self._config['IMAGE_W'], self._config['IMAGE_H']))
         if self._config['IMAGE_C'] == 1:
             image = image[..., np.newaxis]
-        image = image[..., ::-1]
+        image = image[..., ::-1]  # make it RGB (it is important for normalization of some backends)
 
         # fix object's position and size
         for obj in all_objs:


### PR DESCRIPTION
This adds conversion from BGR to RGB in predict.py.
It assumes that backends are expecting RGB (due to normalization).